### PR TITLE
Interpreter type

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,8 @@
     "node_modules",
     "bower_components",
     "output",
-    "test"
+    "test",
+    "vendor"
   ],
   "dependencies": {
     "purescript-xpath": "cryogenian/purescript-xpath#compiler/0.12",

--- a/src/Lunapark.purs
+++ b/src/Lunapark.purs
@@ -6,7 +6,7 @@ module Lunapark
   ) where
 
 
-import Lunapark.API (BaseRun, HandleLunaparkInput, Lunapark, handleLunapark, init, interpret, interpretW3CActions, jsonWireActions, runLunapark, runLunaparkActions, w3cActions)
+import Lunapark.API (Interpreter(..), runInterpreter, BaseRun, HandleLunaparkInput, Lunapark, handleLunapark, init, interpret, interpretW3CActions, jsonWireActions, runLunapark, runLunaparkActions, w3cActions)
 import Lunapark.Error (Error, ErrorType(..), fromJson, fromStringCode, toStringCode, unknownError)
 import Lunapark.ActionF (ActionF(..), LUNAPARK_ACTIONS, TouchF(..), WithAction, _lunaparkActions, buttonDown, buttonUp, click, doubleClick, doubleTap, flick, liftAction, longTap, moveTo, pause, scroll, sendKeys, tap, touchDown, touchUp)
 import Lunapark.LunaparkF (ElementF(..), LUNAPARK, LunaparkF(..), WithLunapark, _lunapark, acceptAlert, addCookie, back, childElement, childElements, clearElement, clickElement, closeWindow, deleteAllCookies, deleteCookie, dismissAlert, elementScreenshot, executeScript, executeScriptAsync, findElement, findElements, forward, fullscreenWindow, getAlertText, getAllCookies, getAttribute, getCookie, getCss, getProperty, getRectangle, getTagName, getText, getTimeouts, getTitle, getUrl, getWindowHandle, getWindowHandles, getWindowRectangle, go, isDisplayed, isEnabled, isSelected, liftLunapark, maximizeWindow, minimizeWindow, performActions, quit, refresh, releaseActions, screenshot, sendAlertText, sendKeysElement, setTimeouts, setWindowRectangle, status, submitElement, switchToFrame, switchToParentFrame, switchToWindow)

--- a/src/Lunapark/API.purs
+++ b/src/Lunapark/API.purs
@@ -33,13 +33,18 @@ import Node.FS.Aff as FS
 import Run as R
 import Run.Except (EXCEPT)
 
+newtype Interpreter r = Interpreter (Lunapark r ~> BaseRun r)
+
+runInterpreter ∷ ∀ r. Interpreter r → Lunapark r ~> BaseRun r
+runInterpreter (Interpreter f) = f
+
 init
-  ∷ ∀ m r a
+  ∷ ∀ m r
   . MonadAff m
   ⇒ MonadRec m
   ⇒ String
   → LT.CapabilitiesRequest
-  → m (Either LE.Error (Lunapark r a → BaseRun r a))
+  → m (Either LE.Error (Interpreter r))
 init uri caps = do
   res ←
     liftAff
@@ -78,7 +83,7 @@ init uri caps = do
         , actionsEnabled
         }
 
-    pure $ interpret input
+    pure $ Interpreter (interpret input)
 
 interpret
   ∷ ∀ r


### PR DESCRIPTION
I needed to introduce this to avoid skolem escape issues / impredicativity - I think they were arising because the interpreter's `a` is qualified at the top of `init` rather than the result being defined as a natural transformation. 

It's a little unfortunate we have to change it here, but it seems the interpreter returned from `init` can't be put into a newtype like this after the fact. Or I couldn't find any way to make it work other than this anyway, aside from `unsafeCoerce`.